### PR TITLE
TUIのデフォルト表示をRunningのみに変更

### DIFF
--- a/src/app/tui/app.rs
+++ b/src/app/tui/app.rs
@@ -59,7 +59,8 @@ impl TuiApp {
         Ok(Self {
             tasks: Vec::new(),
             table_scroll: TableScroll::new(),
-            filter: TaskFilter::All,
+            // Default to showing only running tasks
+            filter: TaskFilter::Running,
             should_quit: false,
             view_mode: ViewMode::TaskList,
             log_scroll_offset: 0,
@@ -88,7 +89,8 @@ impl TuiApp {
         Ok(Self {
             tasks: Vec::new(),
             table_scroll: TableScroll::new(),
-            filter: TaskFilter::All,
+            // Default to showing only running tasks
+            filter: TaskFilter::Running,
             should_quit: false,
             view_mode: ViewMode::TaskList,
             log_scroll_offset: 0,

--- a/tests/tui_tests.rs
+++ b/tests/tui_tests.rs
@@ -528,8 +528,8 @@ fn test_task_filter_cycling_with_tab() {
     app.tasks = tasks;
     app.table_scroll.set_total_items(3);
 
-    // Test initial filter is All
-    assert_eq!(app.filter, TaskFilter::All);
+    // Test initial filter is Running
+    assert_eq!(app.filter, TaskFilter::Running);
 
     // Press Tab to cycle to Running
     let key_tab = KeyEvent::new(KeyCode::Tab, KeyModifiers::NONE);


### PR DESCRIPTION
目的\n- TUI起動時にRunning以外（All/Exited/Killed）が表示されないようにし、初期表示をRunningのみにする。\n\n変更点\n- src/app/tui/app.rs\n  - TuiApp::new / TuiApp::new_with_config の初期フィルタを TaskFilter::Running に変更。\n- tests/tui_tests.rs\n  - 初期フィルタに関するテスト期待値を Running に更新。\n\n動作\n- TUI起動時はRunningのみ表示。\n- Tabキーで Running → Exited → Killed → All と循環。\n\n備考\n- 他のテストファイルにある storage::get_tasks の引数不足によるエラーは本変更とは無関係です（必要なら別PRで対応します）。