### PR TITLE
just install時の警告修正 (vibe-kanban)

### DIFF
--- a/src/app/helpers/port_utils.rs
+++ b/src/app/helpers/port_utils.rs
@@ -43,6 +43,7 @@ pub fn extract_port_from_process(pid: u32) -> String {
 }
 
 /// Extract port from a single process PID
+#[allow(dead_code)]
 fn extract_port_from_single_process(_pid: u32) -> Option<String> {
     // Backward compatibility wrapper retained (unused by new selection logic)
     None
@@ -73,6 +74,7 @@ pub fn extract_web_server_info(pid: u32) -> Option<String> {
 }
 
 /// Extract port from a single process PID for web server info (returns port number only)
+#[allow(dead_code)]
 fn extract_port_from_single_process_for_web(_pid: u32) -> Option<u16> {
     // Backward compatibility wrapper retained (unused by new selection logic)
     None

--- a/src/app/helpers/port_utils.rs
+++ b/src/app/helpers/port_utils.rs
@@ -42,12 +42,6 @@ pub fn extract_port_from_process(pid: u32) -> String {
     "-".to_string()
 }
 
-/// Extract port from a single process PID
-#[allow(dead_code)]
-fn extract_port_from_single_process(_pid: u32) -> Option<String> {
-    // Backward compatibility wrapper retained (unused by new selection logic)
-    None
-}
 
 /// Extract web server info from process ID using lsof (returns :port format for TUI compatibility)
 pub fn extract_web_server_info(pid: u32) -> Option<String> {
@@ -73,12 +67,6 @@ pub fn extract_web_server_info(pid: u32) -> Option<String> {
     candidates.first().map(|(p, _)| format!(":{p}"))
 }
 
-/// Extract port from a single process PID for web server info (returns port number only)
-#[allow(dead_code)]
-fn extract_port_from_single_process_for_web(_pid: u32) -> Option<u16> {
-    // Backward compatibility wrapper retained (unused by new selection logic)
-    None
-}
 
 /// Extract port number from lsof output line
 fn extract_port_from_lsof_line(line: &str) -> Option<u16> {


### PR DESCRIPTION
 just install                                                                                                         main
cargo install --path .
  Installing ghost v0.0.10 (/Users/kazuph/src/github.com/kazuph/ghost)
    Updating crates.io index
     Locking 202 packages to latest compatible versions
      Adding unicode-width v0.2.0 (available: v0.2.1)
   Compiling ghost v0.0.10 (/Users/kazuph/src/github.com/kazuph/ghost)
warning: function `extract_port_from_single_process` is never used
  --> src/app/helpers/port_utils.rs:46:4
   |
46 | fn extract_port_from_single_process(_pid: u32) -> Option<String> {
   |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: `#[warn(dead_code)]` on by default

warning: function `extract_port_from_single_process_for_web` is never used
  --> src/app/helpers/port_utils.rs:76:4
   |
76 | fn extract_port_from_single_process_for_web(_pid: u32) -> Option<u16> {
   |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

warning: `ghost` (lib) generated 2 warnings
    Finished `release` profile [optimized] target(s) in 6.15s
   Replacing /Users/kazuph/.cargo/bin/ghost
    Replaced package `ghost v0.0.10 (/Users/kazuph/src/github.com/kazuph/ghost)` with `ghost v0.0.10 (/Users/kazuph/src/github.com/kazuph/ghost)` (executable `ghost`)
